### PR TITLE
Use HOSTNAME when HOSTALIAS is empty

### DIFF
--- a/nagios-msteams.pl
+++ b/nagios-msteams.pl
@@ -61,6 +61,9 @@ if (not length($nagios{'SERVICESTATE'})) {
     $nagios{'SERVICESTATE'} = $nagios{'HOSTSTATE'};
     $nagios{'SERVICEOUTPUT'} = $nagios{'HOSTOUTPUT'};
 }
+if (not length($nagios{'HOSTALIAS'})) {
+    $nagios{'HOSTALIAS'} = $nagios{'HOSTNAME'};
+}
 $event{'themeColor'} = $color{"$nagios{'SERVICESTATE'}"};
 $event{'title'} = "$nagios{'HOSTALIAS'}/$nagios{'SERVICEDESC'} is $nagios{'SERVICESTATE'}";
 $event{'summary'} = $event{'title'};


### PR DESCRIPTION
I am using Opsview 6 and the `notify_via_nagios` script. Unfortunately, in some cases, the HOSTALIAS variable is not defined, resulting in a pretty useless message card.
I have added a test that swaps HOSTALIAS for HOSTNAME when HOSTALIAS is empty.

I am sure there is a more elegant way to do this but my Perl is kinda... rusty.
At least this patch works for me.