### PR TITLE
Use proxy set by environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ export NAGIOS_HOSTALIAS="hoge101" NAGIOS_SERVICEDESC="http" NAGIOS_SERVICESTATE=
 ./nagios-msteams.pl --webhook 'https://your incoming webhook url'
 ```
 
+Proxy environment variables can be specified using lowercase environment variables ending in "*_proxy".
+
+```
+export http_proxy="http://proxy.example.com/"
+export no_proxy="localhost"
+```
+
 ## installation
 
 1. place the script in nagios plugin directory

--- a/nagios-msteams.pl
+++ b/nagios-msteams.pl
@@ -101,6 +101,7 @@ my $json = encode_json \%event;
 
 my $ua = LWP::UserAgent->new;
 $ua->timeout(15);
+$ua->env_proxy;
 
 my $req = HTTP::Request->new('POST', $webhook);
 $req->header('Content-Type' => 'application/json');


### PR DESCRIPTION
Minor change to make the plugin use the proxy specified in environment variables (if any) like http_proxy.